### PR TITLE
fix: uses the exposed Redot global instead of the no longer existing Godot

### DIFF
--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -93,7 +93,7 @@ const Engine = (function () {
 					return new Promise(function (resolve, reject) {
 						promise.then(function (response) {
 							const cloned = new Response(response.clone().body, { 'headers': [['content-type', 'application/wasm']] });
-							Godot(me.config.getModuleConfig(loadPath, cloned)).then(function (module) {
+							Redot(me.config.getModuleConfig(loadPath, cloned)).then(function (module) {
 								const paths = me.config.persistentPaths;
 								module['initFS'](paths).then(function (err) {
 									me.rtenv = module;


### PR DESCRIPTION
The error this fixes can be reproduced by setting up export templates then clicking 
![image](https://github.com/user-attachments/assets/3822c30f-ca74-4c25-9f30-66d9c12c439d)

![image](https://github.com/user-attachments/assets/4ab19552-f558-44c5-91d9-791fde529d28)

![image](https://github.com/user-attachments/assets/1aabd64d-37ab-4548-81c2-07241e659ffd)

verified that this works by changing the file manually directly inside the export templates zip, but seeing some freezing issues after that in web builds, still unsure if this is a redot or a 4.4 issue
